### PR TITLE
Download dependencies automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ nodes are running inside containers which will on both Linux and macOS.
 
 ## Creating a Firekube cluster
 
-1. Download the latest versions of [footloose][dl-footloose], [jk][dl-jk] and [wksctl][dl-wksctl] as well as [ignite][dl-ignite] (Linux only).
-
 1. Fork this repository.
 
 1. Clone your fork and `cd` into it:
@@ -64,10 +62,6 @@ Enjoy your Kubernetes cluster!
    a5cf619fa058882d   Ready    <none>   75s     v1.14.1
    ```
 
-[dl-footloose]: https://github.com/weaveworks/footloose/releases/tag/0.6.1
-[dl-jk]: https://github.com/jkcfg/jk/releases
-[dl-wksctl]: https://github.com/weaveworks/wksctl/releases
-[dl-ignite]: https://github.com/weaveworks/ignite/releases/tag/v0.5.2
 [gh-ignite]: https://github.com/weaveworks/ignite
 [gh-firecracker]: https://github.com/firecracker-microvm/firecracker
 [kvm]: https://en.wikipedia.org/wiki/Kernel-based_Virtual_Machine

--- a/setup.sh
+++ b/setup.sh
@@ -80,6 +80,14 @@ do_curl() {
     curl --progress-bar -fLo $path $url
 }
 
+do_curl_binary() {
+    local cmd=$1
+    local url=$2
+
+    do_curl ~/.wks/bin/$cmd $url
+    chmod +x ~/.wks/bin/$cmd
+}
+
 # Given $1 and $2 as semantic version numbers like 3.1.2, return [ $1 < $2 ]
 version_lt() {
     VERSION_MAJOR=${1%.*.*}``
@@ -147,8 +155,7 @@ footloose_download() {
     os=$(goos)
     case $os in
     linux)
-        do_curl ~/.wks/bin/$cmd https://github.com/weaveworks/footloose/releases/download/${version}/footloose-${version}-${os}-$(arch)
-        chmod +x ~/.wks/bin/$cmd
+        do_curl_binary $cmd https://github.com/weaveworks/footloose/releases/download/${version}/footloose-${version}-${os}-$(arch)
         ;;
     darwin)
         dldir=$(mktempdir)
@@ -196,8 +203,7 @@ ignite_download() {
     local cmd=$1
     local version=$2
 
-    do_curl ~/.wks/bin/$cmd https://github.com/weaveworks/ignite/releases/download/v${version}/ignite-$(goarch)
-    chmod +x ~/.wks/bin/$cmd
+    do_curl_binary $cmd https://github.com/weaveworks/ignite/releases/download/v${version}/ignite-$(goarch)
 }
 
 ignite_version() {
@@ -230,8 +236,7 @@ jk_download() {
     local cmd=$1
     local version=$2
 
-     do_curl ~/.wks/bin/jk https://github.com/jkcfg/jk/releases/download/${version}/jk-$(goos)-$(goarch)
-     chmod +x ~/.wks/bin/jk
+     do_curl_binary $cmd https://github.com/jkcfg/jk/releases/download/${version}/jk-$(goos)-$(goarch)
 }
 
 jk_version() {

--- a/setup.sh
+++ b/setup.sh
@@ -88,6 +88,18 @@ do_curl_binary() {
     chmod +x ~/.wks/bin/$cmd
 }
 
+do_curl_tarball() {
+    local cmd=$1
+    local url=$2
+
+    dldir=$(mktempdir)
+    mkdir $dldir/$cmd
+    do_curl $dldir/$cmd.tar.gz https://github.com/weaveworks/wksctl/releases/download/${version}/wksctl-${version}-$(goos)-$(arch).tar.gz
+    tar -C $dldir/$cmd -xvf $dldir/$cmd.tar.gz
+    mv $dldir/$cmd/$cmd ~/.wks/bin/$cmd
+    rm -rf $dldir
+}
+
 # Given $1 and $2 as semantic version numbers like 3.1.2, return [ $1 < $2 ]
 version_lt() {
     VERSION_MAJOR=${1%.*.*}``
@@ -158,12 +170,7 @@ footloose_download() {
         do_curl_binary $cmd https://github.com/weaveworks/footloose/releases/download/${version}/footloose-${version}-${os}-$(arch)
         ;;
     darwin)
-        dldir=$(mktempdir)
-        mkdir $dldir/$cmd
-        do_curl $dldir/$cmd.tar.gz https://github.com/weaveworks/footloose/releases/download/${version}/footloose-${version}-${os}-$(arch).tar.gz
-        tar -C $dldir/$cmd -xvf $dldir/$cmd.tar.gz
-        mv $dldir/$cmd/footloose ~/.wks/bin/footloose
-        rm -rf $dldir
+        do_curl_tarball $cmd https://github.com/weaveworks/footloose/releases/download/${version}/footloose-${version}-${os}-$(arch).tar.gz
         ;;
     *)
         error "unknown OS: $os"
@@ -266,12 +273,7 @@ wksctl_download() {
     local cmd=$1
     local version=$2
 
-    dldir=$(mktempdir)
-    mkdir $dldir/$cmd
-    do_curl $dldir/$cmd.tar.gz https://github.com/weaveworks/wksctl/releases/download/${version}/wksctl-${version}-$(goos)-$(arch).tar.gz
-    tar -C $dldir/$cmd -xvf $dldir/$cmd.tar.gz
-    mv $dldir/$cmd/wksctl ~/.wks/bin/wksctl
-    rm -rf $dldir
+    do_curl_tarball $cmd https://github.com/weaveworks/wksctl/releases/download/${version}/wksctl-${version}-$(goos)-$(arch).tar.gz
 }
 
 wksctl_version() {


### PR DESCRIPTION
It was of course, a bit trickier than anyone thought it would be. The script can't actually download the wksctl binary as it's currently a private repository and one would need to talk github API to do it. It could be done as an addition though.

Fixes: https://github.com/weaveworks/wksctl/issues/25 