### PR TITLE
Various fixes to enable "ssh-less flux" and bump wksctl dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,22 +12,13 @@ nodes are running inside containers which will on both Linux and macOS.
 
 1. Fork this repository.
 
-1. Clone your fork and `cd` into it:
+1. Clone your fork and `cd` into it. Use the `https` git URL as it doesn't
+need authentication:
 
    ```console
-   git clone git@github.com:$user/wks-quickstart-firekube.git
+   git clone https://github.com/$user/wks-quickstart-firekube.git
    cd wks-quickstart-firekube
    ```
-
-1. Create an SSH key pair:
-
-   ```console
-   ssh-keygen -t rsa -b 4096 -C "damien+firekube@weave.works" -f deploy-firekube  -N ""
-   ```
-
-1. Upload the deploy key to your fork (with read/write access):
-
-   ![deploy key upload](docs/deploy-key.png)
 
 1. (optional) If you are on macOS or want to use docker containers instead of [firecracker][gh-firecracker] virtual machines, change the backend to `docker` in `config.yaml`:
 
@@ -42,7 +33,7 @@ nodes are running inside containers which will on both Linux and macOS.
 
    ```console
    cd wks-quickstart-firekube
-   ./setup.sh --git-deploy-key  ./deploy-firekube
+   ./setup.sh
    ```
 
    This step will take several minutes.
@@ -66,3 +57,36 @@ Enjoy your Kubernetes cluster!
 [gh-firecracker]: https://github.com/firecracker-microvm/firecracker
 [kvm]: https://en.wikipedia.org/wiki/Kernel-based_Virtual_Machine
 [ww-gitops]: https://www.weave.works/technologies/gitops/
+
+## Using a private git repository with firekube
+
+To use a private git repository instead of a fork of `wks-quickstart-firekube`:
+
+1. Create a private repository and push the `wks-quickstart-firekube`
+   `master` branch there. Use the SSH git URL when cloning the private
+   repository:
+
+   ```
+   git clone git@github.com:$user/$repository.git
+   cd $repository
+   git remote add quickstart git@github.com:weaveworks/wks-quickstart-firekube.git
+   git fetch quickstart
+   git merge quickstart/master
+   git push
+   ```
+
+1. Create an SSH key pair:
+
+   ```console
+   ssh-keygen -t rsa -b 4096 -C "damien+firekube@weave.works" -f deploy-firekube  -N ""
+   ```
+
+1. Upload the deploy key to your private repository (with read/write access):
+
+   ![deploy key upload](docs/deploy-key.png)
+
+1. Start the cluster:
+
+   ```console
+   ./setup.sh --git-deploy-key  ./deploy-firekube
+   ```

--- a/flux.yaml
+++ b/flux.yaml
@@ -114,11 +114,12 @@ items:
           - --git-branch=master
           - --git-poll-interval=30s
           - --git-path="."
+          - --git-readonly
           - --memcached-hostname=memcached.weavek8sops.svc.cluster.local
           - --memcached-service=memcached
           - --listen-metrics=:3031
           - --sync-garbage-collection
-          image: fluxcd/flux:1.13.3
+          image: fluxcd/flux:1.14.2
           imagePullPolicy: IfNotPresent
           name: flux
           ports:

--- a/flux.yaml
+++ b/flux.yaml
@@ -113,7 +113,7 @@ items:
           - --git-url=""
           - --git-branch=master
           - --git-poll-interval=30s
-          - --git-path="."
+          - --git-path=.
           - --git-readonly
           - --memcached-hostname=memcached.weavek8sops.svc.cluster.local
           - --memcached-service=memcached

--- a/setup.sh
+++ b/setup.sh
@@ -100,16 +100,23 @@ do_curl_tarball() {
     rm -rf $dldir
 }
 
+clean_version() {
+    echo $1 | sed -n -e 's#^\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\).*#\1#p'
+}
+
 # Given $1 and $2 as semantic version numbers like 3.1.2, return [ $1 < $2 ]
 version_lt() {
-    VERSION_MAJOR=${1%.*.*}``
-    REST=${1%.*} VERSION_MINOR=${REST#*.}
-    # strip garbage after the patch version
-    VERSION_PATCH=$(echo ${1#*.*.} | sed -n -e 's#\([0-9][0-9]*\).*#\1#p')
+    # clean up the version string
+    local a=$(clean_version $1)
+    local b=$(clean_version $2)
 
-    MIN_VERSION_MAJOR=${2%.*.*}
-    REST=${2%.*} MIN_VERSION_MINOR=${REST#*.}
-    MIN_VERSION_PATCH=${2#*.*.}
+    VERSION_MAJOR=${a%.*.*}
+    REST=${a%.*} VERSION_MINOR=${REST#*.}
+    VERSION_PATCH=${a#*.*.}
+
+    MIN_VERSION_MAJOR=${b%.*.*}
+    REST=${b%.*} MIN_VERSION_MINOR=${REST#*.}
+    MIN_VERSION_PATCH=${b#*.*.}
 
     if [ \( "$VERSION_MAJOR" -lt "$MIN_VERSION_MAJOR" \) -o \
         \( "$VERSION_MAJOR" -eq "$MIN_VERSION_MAJOR" -a \

--- a/setup.sh
+++ b/setup.sh
@@ -187,7 +187,7 @@ footloose_version() {
         help $cmd "error running '$cmd version'."
     fi
 
-    if [ $version == "git" ]; then
+    if [ "$version" == "git" ]; then
         log "$cmd: detected git build, continuing"
         return
     fi
@@ -285,7 +285,7 @@ wksctl_version() {
         help $cmd "error running '$cmd version'."
     fi
 
-    if [ $version == "undefined" ]; then
+    if [ "$version" == "undefined" ]; then
         log "$cmd: detected git build, continuing"
         return
     fi

--- a/setup.sh
+++ b/setup.sh
@@ -183,7 +183,7 @@ footloose_version() {
     local req=$1
     local version
 
-    if ! version=$($cmd version | sed -n -e 's#^version: \(.*\)#\1#p') || [ -z "$version" ]; then
+    if ! version=$($cmd version | sed -n -e 's#^version: \([0-9g][0-9\.it]*\)$#\1#p') || [ -z "$version" ]; then
         help $cmd "error running '$cmd version'."
     fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 JK_VERSION=0.3.0
 FOOTLOOSE_VERSION=0.6.1
 IGNITE_VERSION=0.5.2
-WKSCTL_VERSION=0.7.0
+WKSCTL_VERSION=0.8.0-beta.1
 
 log() {
     echo "•" $*


### PR DESCRIPTION
This PR has various fixes and improvements:

- Bump the version of wksctl (see #5)
- Enable read-only flux for ssh-less setups
- Various robustness fixes in version parsing
- Update the instructions to be deploy key-less by default

Fixes: #5 
Fixes: #2