### PR TITLE
setup: Create the cluster SSH key before footloose does it

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -356,6 +356,13 @@ check_version wksctl $WKSCTL_VERSION
 log "Creating footloose manifest"
 jk generate -f config.yaml setup.js
 
+cluster_key="cluster-key"
+if [ ! -f "$cluster_key" ]; then
+    # Create the cluster ssh key with the user credentials.
+    log "Creating SSH key"
+    ssh-keygen -q -t rsa -b 4096 -C firekube@footloose.mail -f $cluster_key -N ""
+fi
+
 log "Creating virtual machines"
 $sudo footloose create
 


### PR DESCRIPTION
With the firekube backend, footloose needs to be started as root. If the
cluster SSH key has not be created yet, footloose and the file will then be
only readable by root, which will make `wksctl` fail.

By creating the SSH key upfront, we ensure it's always created with the user
uid/gid.

Fixes: #9 