### PR TITLE
flux: Use the upstream wks-quickstart-firekube git URL by default

### DIFF
--- a/flux.yaml
+++ b/flux.yaml
@@ -110,7 +110,7 @@ items:
         containers:
         - args:
           - --ssh-keygen-dir=/var/fluxd/keygen
-          - --git-url=""
+          - --git-url=https://github.com/weaveworks/wks-quickstart-firekube.git
           - --git-branch=master
           - --git-poll-interval=30s
           - --git-path=.


### PR DESCRIPTION
That way, the manifest is a valid one and people can even point use it to
create a cluster pointing at

  https://github.com/weaveworks/wks-quickstart-firekube