### PR TITLE
setup: Fix the missing git-to-http conversion for wksctl apply

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -395,5 +395,5 @@ git diff-index --quiet HEAD || git commit -m "Initial cluster configuration"
 git push
 
 log "Installing Kubernetes cluster"
-wksctl apply --git-url=$(git config --get remote.origin.url) --git-branch=$(git rev-parse --abbrev-ref HEAD) $git_deploy_key
+wksctl apply --git-url=$(git_http_url $(git config --get remote.origin.url)) --git-branch=$(git rev-parse --abbrev-ref HEAD) $git_deploy_key
 wksctl kubeconfig


### PR DESCRIPTION
URL conversion needed for both `init` and `apply`. 

#22 put fix to `init` and this PR put another missing one for `apply`.