### PR TITLE
README: Remove spurious cd

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ push an initial commit to your fork:
 1. Start the cluster:
 
    ```console
-   cd wks-quickstart-firekube
    ./setup.sh
    ```
 


### PR DESCRIPTION
We already cd into the cloned directory in step 1. we don't need to do it
again.