### PR TITLE
Make sure machines are in the weavek8sops namespace to avoid confusing flux

### DIFF
--- a/setup.js
+++ b/setup.js
@@ -81,7 +81,8 @@ const Machine = ({ id, privateIP, sshPort, role }) => ({
     labels: {
       set: role,
     },
-    name: `${role}-${id}`
+    name: `${role}-${id}`,
+    namespace: 'weavek8sops'
   },
   spec: {
     providerSpec: {


### PR DESCRIPTION
Machines were being deployed in the `weavek8sops` namespace by `wksctl` code but the manifests in the git repo were in the `default` namespace. So, flux would re-deploy them and create "extra" machines.
