### PR TITLE
Set the default namespace for the wks-controller manifest to "weavek8sops"

### DIFF
--- a/wks-controller.yaml
+++ b/wks-controller.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: wks-controller
-  namespace: system
+  namespace: weavek8sops
   labels:
     name: wks-controller
     control-plane: wks-controller


### PR DESCRIPTION
We currently have `system` as the namespace for `wks-controller`. It gets replaced with `weavek8sops` during initial deployment but the version in the repo remains at `system`.
