### PR TITLE
use preloaded image

### DIFF
--- a/setup.js
+++ b/setup.js
@@ -18,7 +18,7 @@ const backend = {
     }]
   },
   ignite: {
-    image: 'weaveworks/ignite-centos:latest',
+    image: 'weaveworks/ignite-centos:firekube-pre3',
     privileged: false,
     volumes: [],
   },


### PR DESCRIPTION
This PR proposes a new preloaded image to speed things up.

- It is a change to the Ignite centos image
- It does not change the wksctl apply workflow
- It allows the usual upgrade process