### PR TITLE
Change docker and repo ConfigMap namespaces to weavek8sops

### DIFF
--- a/docker-config.yaml
+++ b/docker-config.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: docker
-  namespace: system
+  namespace: weavek8sops
 data:
   daemon.json: |
     {

--- a/repo-config.yaml
+++ b/repo-config.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: repo
-  namespace: system
+  namespace: weavek8sops
 data:
   kubernetes.repo: |
     [kubernetes]


### PR DESCRIPTION
Fixes #47 

Setup appears to create the docker and repo ConfigMap resources in the `weavek8sops` namespace.  But the `docker-config.yaml `and `repo-config.yaml` files in *wks-quickstart-firekube* specify a `system` namespace, which does not appear to exist in the cluster upon initial creation.

Therefore changing the namespace value defined in `docker-config.yaml` and `repo-config.yaml` files to `weavek8sops`.