### PR TITLE
cd to SCRIPT_DIR before setup or cleanup

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+unset CDPATH
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "${SCRIPT_DIR}" || exit 1
 
 set -euo pipefail
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+unset CDPATH
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "${SCRIPT_DIR}" || exit 1
 
 set -euo pipefail
 


### PR DESCRIPTION
Both of these scripts either create or operate on `./footloose.yaml` which is intended to be created in the same directory as `setup.js` and `config.yaml`.

Use bash features to ensure file operations occur from the same directory regardless of how the script is executed.