### PR TITLE
shellcheck: fix errors, unwrap the version_lt logic

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -3,6 +3,8 @@ unset CDPATH
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "${SCRIPT_DIR}" || exit 1
 
+. lib/functions.sh
+
 # user-overrideable via ENV
 if command -v sudo >/dev/null 2>&1; then
     sudo="${sudo:-"sudo"}"
@@ -11,10 +13,6 @@ else
 fi
 
 set -euo pipefail
-
-log() {
-    echo "•" "$@"
-}
 
 config_backend() {
     sed -n -e 's/^backend: *\(.*\)/\1/p' config.yaml

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -13,7 +13,7 @@ fi
 set -euo pipefail
 
 log() {
-    echo "•" $*
+    echo "•" "$@"
 }
 
 config_backend() {

--- a/lib/footloose.sh
+++ b/lib/footloose.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 footloose_help() {
     echo "firekube requires footloose to spawn VMs that will be used as Kubernetes nodes."
     echo ""

--- a/lib/footloose.sh
+++ b/lib/footloose.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+# shellcheck shell=bash
 
 footloose_help() {
     echo "firekube requires footloose to spawn VMs that will be used as Kubernetes nodes."

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+# shellcheck shell=bash
 
 log() {
     echo "•" "$@"

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 log() {
     echo "•" "$@"
 }
@@ -105,22 +107,21 @@ version_lt() {
     local b
     b="$(clean_version "${2}")"
 
-    VERSION_MAJOR="${a%.*.*}"
-    REST="${a%.*}" VERSION_MINOR="${REST#*.}"
-    VERSION_PATCH="${a#*.*.}"
+    A_MAJOR="${a%.*.*}"
+    REST="${a%.*}" A_MINOR="${REST#*.}"
+    A_PATCH="${a#*.*.}"
 
-    MIN_VERSION_MAJOR="${b%.*.*}"
-    REST="${b%.*}" MIN_VERSION_MINOR="${REST#*.}"
-    MIN_VERSION_PATCH="${b#*.*.}"
+    B_MAJOR="${b%.*.*}"
+    REST="${b%.*}" B_MINOR="${REST#*.}"
+    B_PATCH="${b#*.*.}"
 
-    if [ \( "${VERSION_MAJOR}" -lt "${MIN_VERSION_MAJOR}" \) -o \
-        \( "${VERSION_MAJOR}" -eq "${MIN_VERSION_MAJOR}" -a \
-        \( "${VERSION_MINOR}" -lt "${MIN_VERSION_MINOR}" -o \
-        \( "${VERSION_MINOR}" -eq "${MIN_VERSION_MINOR}" -a \
-        \( "${VERSION_PATCH}" -lt "${MIN_VERSION_PATCH}" \) \) \) \) ] ; then
-        return 0
-    fi
-    return 1
+    [ "${A_MAJOR}" -lt "${B_MAJOR}" ] && return 0
+    [ "${A_MAJOR}" -gt "${B_MAJOR}" ] && return 1
+
+    [ "${A_MINOR}" -lt "${B_MINOR}" ] && return 0
+    [ "${A_MINOR}" -gt "${B_MINOR}" ] && return 1
+
+    [ "${A_PATCH}" -lt "${B_PATCH}" ]
 }
 
 download() {
@@ -169,10 +170,12 @@ check_version() {
 }
 
 git_ssh_url() {
+    # shellcheck disable=SC2001
     echo "${1}" | sed -e 's#^https://github.com/#git@github.com:#'
 }
 
 git_http_url() {
+    # shellcheck disable=SC2001
     echo "${1}" | sed -e 's#^git@github.com:#https://github.com/#'
 }
 

--- a/lib/ignite.sh
+++ b/lib/ignite.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+# shellcheck shell=bash
 
 ignite_help() {
     echo "firekube with the ignite backend requires ignite to spawn VMs that will be used as Kubernetes nodes."

--- a/lib/ignite.sh
+++ b/lib/ignite.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 ignite_help() {
     echo "firekube with the ignite backend requires ignite to spawn VMs that will be used as Kubernetes nodes."
     echo ""

--- a/lib/jk.sh
+++ b/lib/jk.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 jk_help() {
     echo "firekube needs jk to generate configuration manifests."
     echo ""

--- a/lib/jk.sh
+++ b/lib/jk.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+# shellcheck shell=bash
 
 jk_help() {
     echo "firekube needs jk to generate configuration manifests."

--- a/lib/wksctl.sh
+++ b/lib/wksctl.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+# shellcheck shell=bash
 
 wksctl_help() {
     echo "firekube needs wksctl to install Kubernetes."

--- a/lib/wksctl.sh
+++ b/lib/wksctl.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 wksctl_help() {
     echo "firekube needs wksctl to install Kubernetes."
     echo ""

--- a/setup.sh
+++ b/setup.sh
@@ -86,7 +86,7 @@ while test $# -gt 0; do
         ;;
     --git-deploy-key)
         shift
-        git_deploy_key="--git-deploy-key ${1}"
+        git_deploy_key="--git-deploy-key=${1}"
         log "Using git deploy key: ${1}"
         ;;
     -h|--help)
@@ -163,5 +163,10 @@ git diff-index --quiet HEAD || git commit -m "Initial cluster configuration"
 git push "${git_remote}" HEAD
 
 log "Installing Kubernetes cluster"
-wksctl apply --git-url="$(git_http_url "$(git_remote_fetchurl "${git_remote}")")" --git-branch="$(git_current_branch)" "${git_deploy_key}"
+apply_args=(
+  "--git-url=$(git_http_url "$(git_remote_fetchurl "${git_remote}")")"
+  "--git-branch=$(git_current_branch)"
+)
+[ "${git_deploy_key}" ] && apply_args+=("${git_deploy_key}")
+wksctl apply "${apply_args[@]}"
 wksctl kubeconfig

--- a/setup.sh
+++ b/setup.sh
@@ -3,12 +3,17 @@ unset CDPATH
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "${SCRIPT_DIR}" || exit 1
 
-. ${SCRIPT_DIR}/lib/functions.sh
+# shellcheck source=lib/functions.sh
+. "${SCRIPT_DIR}/lib/functions.sh"
 
-. ${SCRIPT_DIR}/lib/footloose.sh
-. ${SCRIPT_DIR}/lib/ignite.sh
-. ${SCRIPT_DIR}/lib/jk.sh
-. ${SCRIPT_DIR}/lib/wksctl.sh
+# shellcheck source=lib/footloose.sh
+. "${SCRIPT_DIR}/lib/footloose.sh"
+# shellcheck source=lib/ignite.sh
+. "${SCRIPT_DIR}/lib/ignite.sh"
+# shellcheck source=lib/jk.sh
+. "${SCRIPT_DIR}/lib/jk.sh"
+# shellcheck source=lib/wksctl.sh
+. "${SCRIPT_DIR}/lib/wksctl.sh"
 
 # user-overrideable via ENV
 if command -v sudo >/dev/null 2>&1; then
@@ -163,5 +168,5 @@ git diff-index --quiet HEAD || git commit -m "Initial cluster configuration"
 git push "${git_remote}" HEAD
 
 log "Installing Kubernetes cluster"
-wksctl apply --git-url="$(git_http_url "$(git_remote_fetchurl "${git_remote}")")" --git-branch="$(git_current_branch)" ${git_deploy_key}
+wksctl apply --git-url="$(git_http_url "$(git_remote_fetchurl "${git_remote}")")" --git-branch="$(git_current_branch)" "${git_deploy_key}"
 wksctl kubeconfig

--- a/setup.sh
+++ b/setup.sh
@@ -3,17 +3,12 @@ unset CDPATH
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "${SCRIPT_DIR}" || exit 1
 
-# shellcheck source=lib/functions.sh
-. "${SCRIPT_DIR}/lib/functions.sh"
+. lib/functions.sh
 
-# shellcheck source=lib/footloose.sh
-. "${SCRIPT_DIR}/lib/footloose.sh"
-# shellcheck source=lib/ignite.sh
-. "${SCRIPT_DIR}/lib/ignite.sh"
-# shellcheck source=lib/jk.sh
-. "${SCRIPT_DIR}/lib/jk.sh"
-# shellcheck source=lib/wksctl.sh
-. "${SCRIPT_DIR}/lib/wksctl.sh"
+. lib/footloose.sh
+. lib/ignite.sh
+. lib/jk.sh
+. lib/wksctl.sh
 
 # user-overrideable via ENV
 if command -v sudo >/dev/null 2>&1; then


### PR DESCRIPTION
Part of #66.

Fixes most of the shellcheck complaints.
Suppresses two - where the suggestion seems impractical (because bash variable expansion would look ugly with many slashes escaped)

One of the warnings referred to the complex logical expression in `version_lt`. Rewrote the expression for easier comprehension (hopefully).

After this PR:
```
$ shellcheck **.sh

In lib/functions.sh line 159:
    if ! command_exists "${cmd}" || [ "${download_force}" == "yes" ]; then
                                       ^---------------^ SC2154: download_force is referenced but not assigned.


In lib/functions.sh line 160:
        if [ "${download}" == "yes" ]; then
              ^---------^ SC2154: download is referenced but not assigned.

For more information:
  https://www.shellcheck.net/wiki/SC2154 -- download is referenced but not as...
```