### PR TITLE
Enable reuse of operations by packaging them

### DIFF
--- a/lib/footloose.sh
+++ b/lib/footloose.sh
@@ -65,3 +65,4 @@ footloose_do() {
         footloose "${@}"
     fi
 }
+

--- a/lib/footloose.sh
+++ b/lib/footloose.sh
@@ -45,3 +45,23 @@ footloose_version() {
 
     version_check "${cmd}" "${version}" "${req}"
 }
+
+footloose_get_config_backend() {
+    sed -n -e 's/^backend: *\(.*\)/\1/p' config.yaml
+}
+
+footloose_set_config_backend() {
+    local tmp=.config.yaml.tmp
+
+    sed -e "s/^backend: .*$/backend: ${1}/" config.yaml > "${tmp}" && \
+        mv "${tmp}" config.yaml && \
+        rm -f "${tmp}"
+}
+
+footloose_do() {
+    if [ "$(footloose_get_config_backend)" == "ignite" ]; then
+        do_sudo env "PATH=${PATH}" footloose "${@}"
+    else
+        footloose "${@}"
+    fi
+}

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -206,3 +206,12 @@ git_remote_fetchurl() {
     git config --get "remote.${1}.url"
 }
 
+ssh_keygen_unless_exists() {
+    cluster_key="${1}"
+
+    [ -f "${cluster_key}" ] && return 0
+
+    # Create the cluster ssh key with the user credentials.
+    log "Creating SSH key"
+    ssh-keygen -q -t rsa -b 4096 -C firekube@footloose.mail -f "${cluster_key}" -N ""
+}

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -79,6 +79,7 @@ do_curl_binary() {
     local cmd="${1}"
     local url="${2}"
 
+    mkdir -p "${HOME}/.wks/bin"
     do_curl "${HOME}/.wks/bin/${cmd}" "${url}"
     chmod +x "${HOME}/.wks/bin/${cmd}"
 }
@@ -89,6 +90,7 @@ do_curl_tarball() {
 
     dldir="$(mktempdir)"
     mkdir "${dldir}/${cmd}"
+    mkdir -p "${HOME}/.wks/bin"
     do_curl "${dldir}/${cmd}.tar.gz" "${url}"
     tar -C "${dldir}/${cmd}" -xvf "${dldir}/${cmd}.tar.gz"
     mv "${dldir}/${cmd}/${cmd}" "${HOME}/.wks/bin/${cmd}"

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -195,6 +195,11 @@ git_current_branch() {
     git symbolic-ref --short HEAD
 }
 
+git_remote_for_branch() {
+  branch="${1}"
+  git config --get "branch.${branch}.remote" || true
+}
+
 git_remote_fetchurl() {
     git config --get "remote.${1}.url"
 }

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -95,6 +95,17 @@ do_curl_tarball() {
     rm -rf "${dldir}"
 }
 
+do_sudo() {
+    # user-overrideable via ENV
+    if command -v sudo >/dev/null 2>&1; then
+        sudo="${sudo:-"sudo"}"
+    else
+        sudo="${sudo}"
+    fi
+
+    "${sudo}" "${@}"
+}
+
 clean_version() {
     echo "${1}" | sed -n -e 's#^\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\).*#\1#p'
 }

--- a/setup.sh
+++ b/setup.sh
@@ -99,9 +99,7 @@ fi
 check_command docker
 check_version jk "${JK_VERSION}"
 check_version footloose "${FOOTLOOSE_VERSION}"
-if [ "$(footloose_get_config_backend)" == "ignite" ]; then
-    check_version ignite "${IGNITE_VERSION}"
-fi
+[ "$(footloose_get_config_backend)" != "ignite" ] || check_version ignite "${IGNITE_VERSION}"
 check_version wksctl "${WKSCTL_VERSION}"
 
 log "Creating footloose manifest"

--- a/setup.sh
+++ b/setup.sh
@@ -91,8 +91,8 @@ FOOTLOOSE_VERSION=0.6.2
 IGNITE_VERSION=0.5.5
 WKSCTL_VERSION=0.8.1
 
-# On macOS, we only support the docker backend.
-if [ "$(goos)" == "darwin" ]; then
+# On non-Linux (incl. MacOS), we only support the docker backend.
+if [ "$(goos)" != "linux" ]; then
     footloose_set_config_backend docker
 fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -58,6 +58,20 @@ while test $# -gt 0; do
     shift
 done
 
+# Constants
+PATH="${HOME}/.wks/bin:${PATH}"
+download="${download:="yes"}"
+download_force="${download_force:="no"}"
+export PATH download force_download
+
+JK_VERSION=0.3.0
+FOOTLOOSE_VERSION=0.6.2
+IGNITE_VERSION=0.5.5
+WKSCTL_VERSION=0.8.1
+cluster_key=${cluster_key:-"cluster-key"}
+git_remote="${git_remote:-$(git_remote_for_branch "$(git_current_branch)")}"
+git_deploy_key="${git_deploy_key:-""}"
+
 # Validations
 if git_current_branch > /dev/null 2>&1; then
     log "Using git branch: $(git_current_branch)"
@@ -79,19 +93,6 @@ Your repo has the following remotes:
 $(git remote -v)"
 fi
 echo
-
-# Constants
-PATH="${HOME}/.wks/bin:${PATH}"
-git_remote="$(git_remote_for_branch "$(git_current_branch)")"
-download="${download:="yes"}"
-download_force="${download_force:="no"}"
-export PATH git_remote download force_download
-
-JK_VERSION=0.3.0
-FOOTLOOSE_VERSION=0.6.2
-IGNITE_VERSION=0.5.5
-WKSCTL_VERSION=0.8.1
-cluster_key=${cluster_key:-"cluster-key"}
 
 # On non-Linux (incl. MacOS), we only support the docker backend.
 if [ "$(goos)" != "linux" ]; then

--- a/setup.sh
+++ b/setup.sh
@@ -81,18 +81,15 @@ fi
 echo
 
 # Constants
+PATH="${HOME}/.wks/bin:${PATH}"
+git_remote="$(git_remote_for_branch "$(git_current_branch)")"
+download="yes"
+export PATH git_remote download
+
 JK_VERSION=0.3.0
 FOOTLOOSE_VERSION=0.6.2
 IGNITE_VERSION=0.5.5
 WKSCTL_VERSION=0.8.1
-
-git_remote="$(git_remote_for_branch "$(git_current_branch)")"
-download="yes"
-
-if [ "${download}" == "yes" ]; then
-    mkdir -p "${HOME}/.wks/bin"
-    export PATH="${HOME}/.wks/bin:${PATH}"
-fi
 
 # On macOS, we only support the docker backend.
 if [ "$(goos)" == "darwin" ]; then

--- a/setup.sh
+++ b/setup.sh
@@ -23,7 +23,7 @@ else
     error "Please checkout a git branch."
 fi
 
-git_remote="$(git config --get "branch.$(git_current_branch).remote" || true)" # fallback to "", user may override
+git_remote="$(git_remote_for_branch "$(git_current_branch)")"
 git_deploy_key=""
 download="yes"
 download_force="no"

--- a/setup.sh
+++ b/setup.sh
@@ -12,21 +12,11 @@ cd "${SCRIPT_DIR}" || exit 1
 
 set -euo pipefail
 
-JK_VERSION=0.3.0
-FOOTLOOSE_VERSION=0.6.2
-IGNITE_VERSION=0.5.5
-WKSCTL_VERSION=0.8.1
-
 if git_current_branch > /dev/null 2>&1; then
     log "Using git branch: $(git_current_branch)"
 else
     error "Please checkout a git branch."
 fi
-
-git_remote="$(git_remote_for_branch "$(git_current_branch)")"
-git_deploy_key=""
-download="yes"
-download_force="no"
 
 setup_help() {
     echo "
@@ -88,6 +78,15 @@ Your repo has the following remotes:
 $(git remote -v)"
 fi
 echo
+
+# Constants
+JK_VERSION=0.3.0
+FOOTLOOSE_VERSION=0.6.2
+IGNITE_VERSION=0.5.5
+WKSCTL_VERSION=0.8.1
+
+git_remote="$(git_remote_for_branch "$(git_current_branch)")"
+download="yes"
 
 if [ "${download}" == "yes" ]; then
     mkdir -p "${HOME}/.wks/bin"

--- a/setup.sh
+++ b/setup.sh
@@ -12,12 +12,6 @@ cd "${SCRIPT_DIR}" || exit 1
 
 set -euo pipefail
 
-if git_current_branch > /dev/null 2>&1; then
-    log "Using git branch: $(git_current_branch)"
-else
-    error "Please checkout a git branch."
-fi
-
 setup_help() {
     echo "
     setup.sh
@@ -63,6 +57,13 @@ while test $# -gt 0; do
     esac
     shift
 done
+
+# Validations
+if git_current_branch > /dev/null 2>&1; then
+    log "Using git branch: $(git_current_branch)"
+else
+    error "Please checkout a git branch."
+fi
 
 if [ "${git_remote}" ]; then
     log "Using git remote: ${git_remote}"


### PR DESCRIPTION
This PR continues what #59 did: enables other scripts (willing to import lib/) to implement operations extending this quickstart, and:
- makes `PATH`  consistent regardless of the `download` variable value (to limit surprising effects)
- makes `$sudo` a function `do_sudo`
- reorganizes and packages most operations as reusable functions