### PR TITLE
flux: enable flag manifest generation

### DIFF
--- a/flux.yaml
+++ b/flux.yaml
@@ -119,6 +119,7 @@ items:
           - --memcached-service=memcached
           - --listen-metrics=:3031
           - --sync-garbage-collection
+          - --manifest-generation=true
           image: fluxcd/flux:1.14.2
           imagePullPolicy: IfNotPresent
           name: flux


### PR DESCRIPTION
This PR adds `--manifest-generation=true` so that we could have `.flux.yaml` to allow manifest generation like `kustomize build`.