### PR TITLE
Changes for wksctl-0.8.2

### DIFF
--- a/cluster.yaml
+++ b/cluster.yaml
@@ -13,7 +13,6 @@ spec:
     value:
       apiVersion: baremetalproviderspec/v1alpha1
       kind: BareMetalClusterProviderSpec
-      sshKeyPath: cluster-key
       user: root
       os:
         files:

--- a/setup.sh
+++ b/setup.sh
@@ -154,7 +154,7 @@ jk generate -f config.yaml -f "${status}" setup.js
 rm -f "${status}"
 
 log "Updating container images and git parameters"
-wksctl init --git-url="$(git_http_url "$(git_remote_fetchurl "${git_remote}")")" --git-branch="$(git_current_branch)"
+wksctl init --git-url="$(git_ssh_url "$(git_remote_fetchurl "${git_remote}")")" --git-branch="$(git_current_branch)"
 
 log "Pushing initial cluster configuration"
 git add config.yaml footloose.yaml machines.yaml flux.yaml wks-controller.yaml
@@ -164,7 +164,8 @@ git push "${git_remote}" HEAD
 
 log "Installing Kubernetes cluster"
 apply_args=(
-  "--git-url=$(git_http_url "$(git_remote_fetchurl "${git_remote}")")"
+  "--git-deploy-key=cluster-key"
+  "--git-url=$(git_ssh_url "$(git_remote_fetchurl "${git_remote}")")"
   "--git-branch=$(git_current_branch)"
 )
 [ "${git_deploy_key}" ] && apply_args+=("${git_deploy_key}")


### PR DESCRIPTION
Use SSH git repo refs by default, and WKSctl now expects cluster-key to be passed in as --git-deploy-key. So, the cluster-key is no longer referenced in cluster.yaml

These were all things I tripped over when I tried using the latest wksctl-0.8.2-alpha3. They should be backwards compatible (but I haven't tested.)