### PR TITLE
cluster.yaml should no longer contain "ssh-key"

### DIFF
--- a/cluster.yaml
+++ b/cluster.yaml
@@ -13,7 +13,6 @@ spec:
     value:
       apiVersion: baremetalproviderspec/v1alpha1
       kind: BareMetalClusterProviderSpec
-      sshKeyPath: cluster-key
       user: root
       os:
         files:


### PR DESCRIPTION
Apparently, when `wksctl` was changed to take a `--ssh-key` argument instead of getting the key file path from `cluster.yaml`, the `cluster.yaml` file in this quickstart was not updated.