### PR TITLE
revert to old ssh key since wksctl version used is still 0.8.1

### DIFF
--- a/cluster.yaml
+++ b/cluster.yaml
@@ -13,6 +13,7 @@ spec:
     value:
       apiVersion: baremetalproviderspec/v1alpha1
       kind: BareMetalClusterProviderSpec
+      sshKeyPath: cluster-key
       user: root
       os:
         files:


### PR DESCRIPTION
The setup script ensures a `wksctl` version >= 0.8.1. I had 0.8.2-alpha.3 (which expects ssh key as an argument). This led to the mistaken removal of the sshKey field in `cluster.yaml`.
