### PR TITLE
Enhancement to Generalize config.yaml settings

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -29,3 +29,8 @@ do_footloose() {
 log "Deleting virtual machines"
 export PATH=~/.wks/bin:${PATH}
 do_footloose delete
+
+# Especially as it relates to ignite machines, we may need to remove because `wksctl apply` 
+# will otherwise fail. This is due to footloose IPs inrementing using CNI bridge IPAM:
+#  sudo cat /var/lib/cni/networks/ignite-cni-bridge/last_reserved_ip.0
+rm -f machines.yaml footloose.yaml

--- a/cluster.yaml
+++ b/cluster.yaml
@@ -13,7 +13,7 @@ spec:
     value:
       apiVersion: baremetalproviderspec/v1alpha1
       kind: BareMetalClusterProviderSpec
-      sshKeyPath: cluster-key
+      # sshKeyPath: cluster-key
       user: root
       os:
         files:

--- a/config.yaml
+++ b/config.yaml
@@ -9,8 +9,49 @@
 #            https://github.com/weaveworks/ignite.
 backend: ignite
 
-# Number of nodes allocated for the Kubernetes control plane and workers.
-controlPlane:
-  nodes: 1
-workers:
-  nodes: 1
+cluster:
+  name: example
+  namespace: weavek8sops
+  controlPlane:
+    nodes: 1
+    cpus: 2 # multiples of 2
+    memory: 1GB
+    diskSize: 5GB
+  workers:
+    nodes: 1
+    cpus: 4 # multiples of 2
+    memory: 1GB
+    diskSize: 10GB
+versions:
+  # https://kubernetes.io/docs/setup/release/version-skew-policy/
+  # https://github.com/kubernetes/kubelet/releases
+  kubelet: 1.17.5
+  # https://github.com/jkcfg/jk/releases
+  jk: 0.4.0
+  # https://github.com/weaveworks/footloose/releases
+  footloose: 0.6.3
+  # https://github.com/weaveworks/ignite/releases
+  ignite: 0.7.0
+  # https://github.com/weaveworks/wksctl/releases
+  wksctl: 0.8.2
+  # https://github.com/docker/docker-ce/releases
+  docker: 19.03.11
+images:
+  # https://github.com/weaveworks/footloose/releases
+  footloose: quay.io/footloose/centos7:0.6.3
+  # https://hub.docker.com/r/weaveworks/ignite-centos/tags
+  ignite: docker.io/weaveworks/ignite-centos:7
+  # https://hub.docker.com/r/weaveworks/ignite-kernel/tags
+  kernel: docker.io/weaveworks/ignite-kernel:5.4.43
+  # Manage cluster and machine descriptions using Git
+  # https://hub.docker.com/r/weaveworks/wksctl-controller/tags
+  wksctl: docker.io/weaveworks/wksctl-controller:v0.8.2
+  # CD propagation of images and config changes to the cluster
+  # https://github.com/fluxcd/flux/releases
+  # https://hub.docker.com/r/fluxcd/flux/tags
+  flux: docker.io/fluxcd/flux:1.19.0
+  # General-purpose distributed memory object caching system
+  # https://github.com/memcached/memcached/wiki/ReleaseNotes
+  # https://hub.docker.com/_/memcached?tab=tags
+  memcached: docker.io/memcached:1.6.6
+  # https://github.com/weaveworks/weave/releases/ #download/v2.6.2/weave

--- a/setup.js
+++ b/setup.js
@@ -18,7 +18,13 @@ const backend = {
     }]
   },
   ignite: {
-    image: 'weaveworks/ignite-centos:firekube-pre3',
+    image: config.images.ignite,
+    ignite: {
+      cpus: config.cluster.cpus,
+      memory: config.cluster.memory,
+      diskSize: config.cluster.diskSize,
+      kernel: config.images.kernel,
+    }, 
     privileged: false,
     volumes: [],
   },
@@ -27,6 +33,7 @@ const backend = {
 const image = config => backend[config.backend].image;
 const privileged = config => backend[config.backend].privileged;
 const volumes = config => backend[config.backend].volumes;
+const ignite = config => backend[config.backend].ignite;
 
 const footloose = config => ({
   cluster: {
@@ -36,15 +43,10 @@ const footloose = config => ({
   machines: [{
     count: numNodes(config),
     spec: {
-      image: image(config),
       name: 'node%d',
+      image: image(config),
       backend: config.backend,
-      ignite: {
-        cpus: 2,
-        memory: '1GB',
-        diskSize: '5GB',
-        kernel: 'weaveworks/ignite-kernel:4.19.47',
-      },
+      ignite: ignite(config),
       portMappings: [{
         containerPort: 22,
         hostPort: 2222,

--- a/setup.js
+++ b/setup.js
@@ -6,7 +6,7 @@ let output = [];
 
 const backend = {
   docker: {
-    image: 'quay.io/footloose/centos7:0.6.0',
+    image: config.images.footloose,
     // The below is required for dockerd to run smoothly.
     // See also: https://github.com/weaveworks/footloose#running-dockerd-in-container-machines
     privileged: true,
@@ -42,7 +42,7 @@ const work_node = config => backend[config.backend].work_node;
 
 const footloose = config => ({
   cluster: {
-    name: 'firekube',
+    name: config.cluster.name,
     privateKey: 'cluster-key',
   },
   machines: [{
@@ -111,7 +111,7 @@ const Machine = ({ id, privateIP, sshPort, role }) => ({
       set: role,
     },
     name: `${role}-${id}`,
-    namespace: 'weavek8sops'
+    namespace: config.cluster.namespace
   },
   spec: {
     providerSpec: {
@@ -127,6 +127,9 @@ const Machine = ({ id, privateIP, sshPort, role }) => ({
           port: 22,
         }
       }
+    },
+    versions: {
+      kubelet: config.versions.kubelet
     }
   }
 });
@@ -136,7 +139,7 @@ const sshPort = machine => machine.ports.find(p => p.guest == 22).host;
 if (config.machines !== undefined) {
   const machines = [];
 
-  for (let i = 0; i < config.controlPlane.nodes; i++ ) {
+  for (let i = 0; i < config.cluster.controlPlane.nodes; i++ ) { 
     const machine = config.machines[i];
     machines.push(Machine({
       id: i,
@@ -146,8 +149,8 @@ if (config.machines !== undefined) {
     }));
   }
 
-  for (let i = 0; i < config.workers.nodes; i++ ) {
-    const machine = config.machines[config.controlPlane.nodes + i];
+  for (let i = 0; i < config.cluster.workers.nodes; i++ ) {
+    const machine = config.machines[config.cluster.controlPlane.nodes + i];
     machines.push(Machine({
       id: i,
       privateIP: machine.runtimeNetworks[0].ip,

--- a/setup.sh
+++ b/setup.sh
@@ -134,7 +134,9 @@ if [ "$(config_backend)" == "ignite" ]; then
 fi
 check_version wksctl "${WKSCTL_VERSION}"
 
-log "Creating footloose manifest"
+set_docker_version ${config_versions_docker}
+
+log "Creating footloose manifests"
 jk generate -f config.yaml setup.js
 
 cluster_key="cluster-key"


### PR DESCRIPTION
### Idea: Treat "Installation files" like Cattle
Enhanced the _config.yaml_ file to centralize the initial configuration settings onto one file and avoid having to manually update the installation files. Added and relocated functions to functions.sh. Corresponding updates to `setup.sh`, and `setup.js` were made to correctly process the _config.yaml_. 

Benefits:

1. Centralized configuration settings are leveraged by `jk` to systematically generate the _footloose.yaml_ and _machine.yaml_ files. 
2. Separate node settings for control plane and worker nodes.
3. Ease of updating to latest software releases

The `parse_yaml()` function, reads the whole config.yaml file and assigns each value to variables created using the yaml keys (e.g. "config_" + key1 + key1.1 + key1.2...). Credit for `parse_yaml()` to [Stefan Farestam](https://stackoverflow.com/users/1792684/stefan-farestam) via Stack Overflow.

Updated software release versions in the config.yaml to the latest supported versions where older releases where no longer supported. To ensure that stale data doesn't hang around, added `rm -f machines.yaml footloose.yaml` to `cleanup.sh` 